### PR TITLE
Fix navigation links and index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,11 +72,11 @@
 
     <div class="section">
       <div class="header">Frameworki</div>
-      <div class="prompt">[REMOR] — system narracji i decyzji</div>
-      <div class="prompt">[MEMORA] — pamięć i śledzenie zmian</div>
-      <div class="prompt">[CoreForge] — silnik AI i struktur poznawczych</div>
-      <div class="prompt">[BackFork] — alternatywne wersje i testowanie</div>
-      <div class="prompt">[NeuroField] — systemy mapowania i refleksji</div>
+      <div class="prompt"><a href="remor_page.html">REMOR</a> — system narracji i decyzji</div>
+      <div class="prompt"><a href="memora_page.html">MEMORA</a> — pamięć i śledzenie zmian</div>
+      <div class="prompt"><a href="coreforge_page.html">CoreForge</a> — silnik AI i struktur poznawczych</div>
+      <div class="prompt"><a href="backfork_page.html">BackFork</a> — alternatywne wersje i testowanie</div>
+      <div class="prompt"><a href="neurofield_page.html">NeuroField</a> — systemy mapowania i refleksji</div>
     </div>
 
     <div class="section">

--- a/neurofield_page.html
+++ b/neurofield_page.html
@@ -81,12 +81,12 @@
     <div class="section">
       <div class="header">Frameworki</div>
       <ul class="framework-list">
-        <li><a href="remor.html">REMOR</a> — system narracji i decyzji</li>
-        <li><a href="memora.html">MEMORA</a> — pamięć i śledzenie zmian</li>
-        <li><a href="hermes.html">HERMES</a> — komunikacja i semantyczny przekład</li>
-        <li><a href="coreforge.html">CoreForge</a> — silnik AI i struktur poznawczych</li>
-        <li><a href="backfork.html">BackFork</a> — testowanie wariantów i ścieżek</li>
-        <li><a href="neurofield.html">NeuroField</a> — mapa procesów poznawczych</li>
+        <li><a href="remor_page.html">REMOR</a> — system narracji i decyzji</li>
+        <li><a href="memora_page.html">MEMORA</a> — pamięć i śledzenie zmian</li>
+        <li><a href="hermes_page.html">HERMES</a> — komunikacja i semantyczny przekład</li>
+        <li><a href="coreforge_page.html">CoreForge</a> — silnik AI i struktur poznawczych</li>
+        <li><a href="backfork_page.html">BackFork</a> — testowanie wariantów i ścieżek</li>
+        <li><a href="neurofield_page.html">NeuroField</a> — mapa procesów poznawczych</li>
       </ul>
     </div>
 
@@ -108,6 +108,12 @@
     </div>
 
     <div class="section">
+      <div class="header">↩ Powrót</div>
+      <div class="prompt"><a href="index.html">← przestrzen-czterech.net</a></div>
+      <div class="prompt">Mail: <a href="mailto:krokosz.ops@gmail.com">krokosz.ops@gmail.com</a></div>
+      <div class="prompt">Framework NeuroField – wersja 1.0 / PUBLIC PREVIEW</div>
+    </div>
+
       <div class="header">Kontakt</div>
       <div class="prompt">Mail: <a href="mailto:krokosz.ops@gmail.com">krokosz.ops@gmail.com</a></div>
       <div class="prompt">Status: <span class="highlight">ALFA / Netrunner UI / Edgerunners Build v0.3</span></div>


### PR DESCRIPTION
## Summary
- rename `cyberpunk_mvp_site.html` to `index.html`
- link framework list on the main page to each framework subpage
- correct broken links in `neurofield_page.html`
- add missing "Powrót" section in `neurofield_page.html`

## Testing
- `git diff --cached --name-status`


------
https://chatgpt.com/codex/tasks/task_e_68502e851a3883219a8d8c1d7102b0ff