### PR TITLE
Refactor Luna page to use module-based AI

### DIFF
--- a/luna-ai.js
+++ b/luna-ai.js
@@ -1,10 +1,12 @@
-let responses = {};
-
-fetch('responses.json')
+let responses;
+const responsesPromise = fetch('responses.json')
   .then(res => res.json())
-  .then(data => { responses = data; });
+  .then(data => {
+    responses = data;
+  });
 
-function getLunaResponse(inputText) {
+async function getLunaResponse(inputText) {
+  await responsesPromise;
   const keys = Object.keys(responses);
   const lower = inputText.toLowerCase();
 

--- a/luna.html
+++ b/luna.html
@@ -53,33 +53,18 @@
     <input type="text" id="luna-input" placeholder="Zadaj pytanie lub zostaw sygnał...">
   </div>
 
-  <script>
+  <script type="module">
+    import { getLunaResponse } from './luna-ai.js';
+
     const log = document.getElementById('luna-log');
     const input = document.getElementById('luna-input');
-    let responses = {};
 
-    fetch('responses.json')
-      .then(res => res.json())
-      .then(data => { responses = data; });
-
-    function getLunaResponse(inputText) {
-      const keys = Object.keys(responses);
-      const lower = inputText.toLowerCase();
-
-      for (let key of keys) {
-        if (lower.includes(key)) {
-          return `LUNA: ${responses[key]}`;
-        }
-      }
-      return `LUNA: ${responses['default']}`;
-    }
-
-    input.addEventListener('keydown', function(event) {
+    input.addEventListener('keydown', async function(event) {
       if (event.key === 'Enter') {
         const msg = input.value.trim();
         if (!msg) return;
         log.innerHTML += `\nTY: ${msg}`;
-        let response = getLunaResponse(msg);
+        const response = await getLunaResponse(msg);
         log.innerHTML += `\n${response}`;
         log.scrollTop = log.scrollHeight;
         input.value = '';


### PR DESCRIPTION
## Summary
- clean up `luna.html` script and use module import
- refactor `luna-ai.js` to export an async function that waits for the responses file

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68504a352dfc8321b30e661837fe77a5