### PR TITLE
Fix neurofield trace redirect

### DIFF
--- a/mvpsite_v_2_terminal.html
+++ b/mvpsite_v_2_terminal.html
@@ -122,7 +122,7 @@
           }
         } else if (cmd === 'trace neurofield') {
           setTimeout(() => {
-            window.location.href = 'map.html';
+            window.location.href = 'neurofield_page.html';
           }, 1000);
         } else if (cmd === 'clear') {
           log.innerHTML = '';


### PR DESCRIPTION
## Summary
- fix the `trace neurofield` command redirect
- search and remove references to non-existent `map.html`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68523984ad448321b9dc51e5c29362e8