### PR TITLE
Fix quoting for profile errors

### DIFF
--- a/profile_extras.js
+++ b/profile_extras.js
@@ -63,10 +63,11 @@ function routeCommandExtended(command) {
 
   const result = profiles[name];
   if (!result) {
-    const errorLine = document.createElement("div");
-    errorLine.classList.add("terminal-line");
-    errorLine.textContent = `[ERROR] PROFIL '${name}' NIE ISTNIEJE`;
-    terminal.appendChild(errorLine);
+    const errDiv = Object.assign(document.createElement('div'), {
+      className: 'terminal-line',
+      textContent: `[ERROR] PROFIL '${name}' NIE ISTNIEJE`
+    });
+    terminal.appendChild(errDiv);
     return true;
   }
 


### PR DESCRIPTION
## Summary
- tweak profile error handling using `Object.assign`
- verified optional sync line uses proper quoting

## Testing
- `node test_index.js`

------
https://chatgpt.com/codex/tasks/task_e_685309d3db6c8321bcb57b9c745de173