### PR TITLE
Improve mobile layout for terminal

### DIFF
--- a/v2_terminal/mvpsite_v_2_terminal.html
+++ b/v2_terminal/mvpsite_v_2_terminal.html
@@ -6,21 +6,29 @@
   <title>NetTerm v2 – MVP Interface</title>
   <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
   <style>
-    body {
+    html, body {
       margin: 0;
+      padding: 0;
+      width: 100vw;
+      height: 100vh;
+      overflow-x: hidden;
+    }
+    body {
       background: #000;
       color: #00ff99;
       font-family: 'VT323', monospace;
-      font-size: 20px;
-      padding: 20px;
+      font-size: clamp(12px, 2.5vw, 18px);
+      padding: 10px;
+      box-sizing: border-box;
     }
     .terminal {
-      max-width: 900px;
-      margin: auto;
+      width: 100%;
+      height: 100%;
       border: 2px solid #00ff99;
-      padding: 20px;
+      padding: 10px;
       background-color: #050505;
       box-shadow: 0 0 15px #00ff99;
+      box-sizing: border-box;
     }
     .prompt::before {
       content: '> ';

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -1,16 +1,23 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow-x: hidden;
+}
+
 body {
   background: #000;
-  margin: 0;
   font-family: 'Share Tech Mono', monospace;
   color: #00ffc3;
-  overflow-x: hidden;
+  font-size: clamp(12px, 2.5vw, 18px);
 }
 
 .terminal {
   padding: 30px;
-  max-width: 800px;
-  margin: 0 auto;
-  min-height: 100vh;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
   line-height: 1.4;
   position: relative;
   z-index: 2;
@@ -56,14 +63,8 @@ body {
 }
 
 @media (max-width: 600px) {
-  body {
-    font-size: 14px;
-  }
   .terminal {
     padding: 15px;
-  }
-  .terminal-input {
-    font-size: 0.9em;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak v2 terminal CSS for full screen layout and responsive fonts
- update legacy HTML terminal page with mobile friendly styles and viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531b371b0883219a9a70f90c4226e5