### PR TITLE
Add ads_core module for dynamic ads injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,5 +114,6 @@ introAnim();
 
   </script>
   <!-- Hint: use `inject profile:luna.core` after re-enabling the legacy interface in v1_luna_legacy/ -->
+  <script src="v2_terminal/ads_core.js"></script>
 </body>
 </html>

--- a/v2_terminal/ads_core.js
+++ b/v2_terminal/ads_core.js
@@ -1,0 +1,73 @@
+(function(){
+  const ADS_PATH = 'v2_terminal/ads_news_matrix.json';
+  let adsEntries = [];
+  let started = false;
+
+  function fetchAds(){
+    return fetch(ADS_PATH)
+      .then(res => res.json())
+      .then(data => { adsEntries = data.entries || []; });
+  }
+
+  function randomEntry(){
+    return adsEntries[Math.floor(Math.random() * adsEntries.length)];
+  }
+
+  function createLine(text, cls){
+    const d = document.createElement('div');
+    d.classList.add('terminal-line');
+    if(cls) d.classList.add(cls);
+    d.textContent = text;
+    return d;
+  }
+
+  function displayEntry(entry){
+    if(!entry) return;
+    const terminal = document.getElementById('terminal');
+    if(!terminal) return;
+    let el;
+    switch(entry.type){
+      case 'ascii_banner':
+        el = createLine(entry.style + (entry.content ? '\n'+entry.content : ''), 'ad-banner');
+        break;
+      case 'headline_alert':
+        el = createLine(`${entry.style} ${entry.content}`, 'headline-alert');
+        break;
+      case 'glitch_scroll':
+        el = createLine(`${entry.style} ${entry.content}`, 'glitch-scroll');
+        break;
+      case 'corporate_quote':
+        el = createLine(`${entry.style} ${entry.content}`, 'corporate-quote');
+        break;
+      case 'error_popup':
+        el = createLine(`${entry.style} ${entry.content}`, 'error-popup');
+        break;
+      default:
+        el = createLine(entry.content || '');
+    }
+    terminal.appendChild(el);
+    terminal.scrollTop = terminal.scrollHeight;
+  }
+
+  function injectAd(){
+    if(!adsEntries.length){
+      fetchAds().then(()=>displayEntry(randomEntry()));
+      return;
+    }
+    displayEntry(randomEntry());
+  }
+
+  function schedule(){
+    const delay = 30000 + Math.random()*15000;
+    setTimeout(()=>{ injectAd(); schedule(); }, delay);
+  }
+
+  function start(){
+    if(started) return;
+    started = true;
+    fetchAds().then(schedule);
+  }
+
+  window.adsCore = { start, injectAd };
+  window.addEventListener('load', start);
+})();

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -73,3 +73,33 @@ body {
   50% { opacity: 1; }
   100% { opacity: 0.95; }
 }
+
+.ad-banner {
+  color: #ffa500;
+}
+
+.headline-alert {
+  color: #ff0077;
+  font-weight: bold;
+}
+
+.glitch-scroll {
+  color: #00aaff;
+  animation: scroll-glitch 4s linear infinite;
+}
+
+.corporate-quote {
+  font-style: italic;
+  color: #88f;
+}
+
+.error-popup {
+  background: rgba(255, 0, 0, 0.2);
+  color: #ff0000;
+  padding: 2px 4px;
+}
+
+@keyframes scroll-glitch {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-1ch); }
+}

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -25,8 +25,14 @@ function routeCommand(command) {
       showSearchResults(query);
       break;
 
+    case command === "inject ads_core":
+      if (window.adsCore && typeof window.adsCore.injectAd === "function") {
+        window.adsCore.injectAd();
+      }
+      break;
+
     case command === "help":
-      line.textContent = "COMMANDS: inject profile:<name> | trace:<name> | link:<name> | db:search <term> | clear";
+      line.textContent = "COMMANDS: inject profile:<name> | trace:<name> | link:<name> | db:search <term> | inject ads_core | clear";
       terminal.appendChild(line);
       break;
 


### PR DESCRIPTION
## Summary
- add dynamic ad injection module in `v2_terminal/ads_core.js`
- style ad types in `v2_terminal/style.css`
- support `inject ads_core` command via router
- load the new module from `index.html`

## Testing
- `git status --short`
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_68531c1a91e48321a7e52c322d6fa4f9