### PR TITLE
Fix mobile terminal wrap

### DIFF
--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -23,6 +23,21 @@ body {
   z-index: 2;
 }
 
+#terminal {
+  width: 100vw;
+  height: 100vh;
+  overflow-x: hidden;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: 'Courier New', monospace;
+  font-size: clamp(12px, 2.5vw, 18px);
+  line-height: 1.3;
+  padding: 10px;
+  box-sizing: border-box;
+  background-color: #000;
+  color: #00ff99;
+}
+
 .overlay::before {
   content: "";
   position: fixed;
@@ -41,7 +56,7 @@ body {
 }
 
 .terminal-line {
-  white-space: pre;
+  white-space: pre-wrap;
   animation: flicker 1s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- style #terminal for better wrapping on small screens
- wrap `.terminal-line` content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531d8503948321ab004bb979fab66a