### PR TITLE
Implement dual column terminal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <div class="overlay"></div>
-  <div id="terminal" class="terminal"></div>
+  <div id="main-container">
+    <div id="terminal" class="terminal"></div>
+    <div id="sidefeed"></div>
+  </div>
   <!-- core routing + extras -->
   <script src="v2_terminal/terminal_router_final.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>

--- a/v2_terminal/ads_core.js
+++ b/v2_terminal/ads_core.js
@@ -2,6 +2,17 @@
   const ADS_PATH = 'v2_terminal/ads_news_matrix.json';
   let adsEntries = [];
   let started = false;
+  const sideFeed = document.getElementById('sidefeed');
+
+  function pushFeedMessage(message, cls){
+    if(!sideFeed) return;
+    const msg = document.createElement('div');
+    msg.classList.add('terminal-line');
+    if(cls) msg.classList.add(cls);
+    msg.textContent = message;
+    sideFeed.appendChild(msg);
+    sideFeed.scrollTop = sideFeed.scrollHeight;
+  }
 
   function fetchAds(){
     return fetch(ADS_PATH)
@@ -23,30 +34,33 @@
 
   function displayEntry(entry){
     if(!entry) return;
-    const terminal = document.getElementById('terminal');
-    if(!terminal) return;
-    let el;
+    let text;
+    let cls;
     switch(entry.type){
       case 'ascii_banner':
-        el = createLine(entry.style + (entry.content ? '\n'+entry.content : ''), 'ad-banner');
+        text = entry.style + (entry.content ? '\n'+entry.content : '');
+        cls = 'ad-banner';
         break;
       case 'headline_alert':
-        el = createLine(`${entry.style} ${entry.content}`, 'headline-alert');
+        text = `${entry.style} ${entry.content}`;
+        cls = 'headline-alert';
         break;
       case 'glitch_scroll':
-        el = createLine(`${entry.style} ${entry.content}`, 'glitch-scroll');
+        text = `${entry.style} ${entry.content}`;
+        cls = 'glitch-scroll';
         break;
       case 'corporate_quote':
-        el = createLine(`${entry.style} ${entry.content}`, 'corporate-quote');
+        text = `${entry.style} ${entry.content}`;
+        cls = 'corporate-quote';
         break;
       case 'error_popup':
-        el = createLine(`${entry.style} ${entry.content}`, 'error-popup');
+        text = `${entry.style} ${entry.content}`;
+        cls = 'error-popup';
         break;
       default:
-        el = createLine(entry.content || '');
+        text = entry.content || '';
     }
-    terminal.appendChild(el);
-    terminal.scrollTop = terminal.scrollHeight;
+    pushFeedMessage(text, cls);
   }
 
   function injectAd(){

--- a/v2_terminal/mvpsite_v_2_terminal.html
+++ b/v2_terminal/mvpsite_v_2_terminal.html
@@ -21,14 +21,33 @@
       padding: 10px;
       box-sizing: border-box;
     }
+    #main-container {
+      display: flex;
+      flex-direction: row;
+      height: 100vh;
+      width: 100vw;
+      overflow: hidden;
+    }
     .terminal {
-      width: 100%;
-      height: 100%;
+      flex: 2;
+      width: auto;
+      height: 100vh;
       border: 2px solid #00ff99;
       padding: 10px;
       background-color: #050505;
       box-shadow: 0 0 15px #00ff99;
       box-sizing: border-box;
+      overflow-y: auto;
+    }
+    #sidefeed {
+      flex: 1;
+      padding: 10px;
+      font-family: monospace;
+      background-color: #050505;
+      color: #66ff66;
+      border-left: 2px solid #111;
+      overflow-y: auto;
+      font-size: 12px;
     }
     .prompt::before {
       content: '> ';
@@ -50,19 +69,33 @@
       white-space: pre-wrap;
       margin-bottom: 10px;
     }
+    @media screen and (max-width: 768px) {
+      #main-container {
+        flex-direction: column;
+      }
+
+      #sidefeed {
+        height: 30vh;
+        border-left: none;
+        border-top: 2px solid #111;
+      }
+    }
   </style>
 </head>
 <body>
-  <div class="terminal">
-    <div id="log" class="log">
-      :: SYSTEM ONLINE
-      :: Witaj w NetTerm v2 Interface
-      :: Wpisz 'help' aby zobaczyć dostępne komendy
+  <div id="main-container">
+    <div id="terminal" class="terminal">
+      <div id="log" class="log">
+        :: SYSTEM ONLINE
+        :: Witaj w NetTerm v2 Interface
+        :: Wpisz 'help' aby zobaczyć dostępne komendy
+      </div>
+      <div class="input-line">
+        <span class="prompt"></span>
+        <input type="text" id="terminal-input" autofocus autocomplete="off">
+      </div>
     </div>
-    <div class="input-line">
-      <span class="prompt"></span>
-      <input type="text" id="terminal-input" autofocus autocomplete="off">
-    </div>
+    <div id="sidefeed"></div>
   </div>
 
   <script type="module">

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -118,3 +118,42 @@ body {
   0% { transform: translateX(0); }
   100% { transform: translateX(-1ch); }
 }
+
+/* Dual column layout */
+#main-container {
+  display: flex;
+  flex-direction: row;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+#terminal {
+  flex: 2;
+  width: auto;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+#sidefeed {
+  flex: 1;
+  padding: 10px;
+  font-family: monospace;
+  background-color: #050505;
+  color: #66ff66;
+  border-left: 2px solid #111;
+  overflow-y: auto;
+  font-size: 12px;
+}
+
+@media screen and (max-width: 768px) {
+  #main-container {
+    flex-direction: column;
+  }
+
+  #sidefeed {
+    height: 30vh;
+    border-left: none;
+    border-top: 2px solid #111;
+  }
+}

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -1,4 +1,13 @@
 
+const sideFeed = document.getElementById("sidefeed");
+function pushFeedMessage(message) {
+  if (!sideFeed) return;
+  const msg = document.createElement("div");
+  msg.textContent = message;
+  sideFeed.appendChild(msg);
+  sideFeed.scrollTop = sideFeed.scrollHeight;
+}
+
 function routeCommand(command) {
   const terminal = document.getElementById("terminal");
   const line = document.createElement("div");
@@ -28,6 +37,7 @@ function routeCommand(command) {
     case command === "inject ads_core":
       if (window.adsCore && typeof window.adsCore.injectAd === "function") {
         window.adsCore.injectAd();
+        pushFeedMessage("[ADS] manual injection");
       }
       break;
 


### PR DESCRIPTION
## Summary
- layout split with new `#sidefeed` feed column
- ads now routed into the side feed
- allow manual ad injection to display message in feed
- responsive flex styling

## Testing
- `npm --version`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6853243cad6883219eeeeb24cde5fc77