### PR TITLE
Fix profile injection flow

### DIFF
--- a/v2_terminal/profile_extras.js
+++ b/v2_terminal/profile_extras.js
@@ -4,6 +4,12 @@ function routeCommandExtended(command) {
   }
 
   const name = command.split(":")[1];
+  // Trigger the base profile display so corporate source lines
+  // (handled in terminal_router_final.js) show up prior to
+  // extended information.
+  if (typeof displayProfile === "function") {
+    displayProfile(name);
+  }
   const terminal = document.getElementById("terminal");
 
   const profiles = {

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -78,6 +78,14 @@ function displayProfile(name) {
   line.classList.add("terminal-line");
   line.textContent = profiles[name] || `[ERROR] PROFIL '${name}' NIE ISTNIEJE`;
   terminal.appendChild(line);
+
+  // Display a hint for sourcing additional corporate data
+  if (profiles[name]) {
+    const srcLine = document.createElement("div");
+    srcLine.classList.add("terminal-line");
+    srcLine.textContent = "\u2192 ACCESS SOURCE";
+    terminal.appendChild(srcLine);
+  }
 }
 
 function showTrace(name) {


### PR DESCRIPTION
## Summary
- trigger base profile output from extended profile handler
- show "ACCESS SOURCE" hint when displaying a profile

## Testing
- `node simulate.js`

------
https://chatgpt.com/codex/tasks/task_e_685328e4a160832187ecdf3c1193242f