### PR TITLE
Ensure base profile output before extended info

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,9 +100,11 @@ function createInput(){
       if(cmd){addLine("> "+cmd);}
       inp.disabled=true; clearTimeout(idle);
 
-      const handledExtras = typeof routeCommandExtended==="function" && routeCommandExtended(cmd);
-      if(!handledExtras && typeof routeCommand === "function"){
+      if(typeof routeCommand === "function"){
         routeCommand(cmd);
+      }
+      if(typeof routeCommandExtended === "function"){
+        routeCommandExtended(cmd);
       }
       setTimeout(()=>{createInput(); startIdle();}, 400);
     }

--- a/v2_terminal/profile_extras.js
+++ b/v2_terminal/profile_extras.js
@@ -1,15 +1,11 @@
+// Adds extended profile details after the base displayProfile()
+// is executed via routeCommand in index.html.
 function routeCommandExtended(command) {
   if (!command.startsWith("inject profile:")) {
     return false;
   }
 
   const name = command.split(":")[1];
-  // Trigger the base profile display so corporate source lines
-  // (handled in terminal_router_final.js) show up prior to
-  // extended information.
-  if (typeof displayProfile === "function") {
-    displayProfile(name);
-  }
   const terminal = document.getElementById("terminal");
 
   const profiles = {


### PR DESCRIPTION
## Summary
- call `routeCommand` before `routeCommandExtended` in the input handler
- update `profile_extras.js` so it only prints extended info

## Testing
- `node -e "const {JSDOM}=require('jsdom');const fs=require('fs');const h='<div id=\"terminal\"></div><div id=\"sidefeed\"></div>';const d=new JSDOM(h,{runScripts:'outside-only'});Object.assign(global,{window:d.window,document:d.window.document});window.eval(fs.readFileSync('v2_terminal/terminal_router_final.js','utf8'));window.eval(fs.readFileSync('v2_terminal/profile_extras.js','utf8'));window.routeCommand('inject profile:krokiet');window.routeCommandExtended('inject profile:krokiet');console.log([...document.querySelectorAll('#terminal .terminal-line')].map(e=>e.textContent.trim()).join('\n'))"

------
https://chatgpt.com/codex/tasks/task_e_685334e935f88321908e1066e8aefb45