### PR TITLE
Implement feed routing utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
   <div class="overlay"></div>
   <div id="main-container">
     <div id="terminal" class="terminal"></div>
-    <div id="sidefeed"></div>
+    <div id="sidefeed">
+      <div id="glitch-body"></div>
+      <div id="event-body"></div>
+      <div id="ads-body"></div>
+    </div>
   </div>
   <!-- core routing + extras -->
   <script src="v2_terminal/terminal_router_final.js"></script>

--- a/v2_terminal/ads_core.js
+++ b/v2_terminal/ads_core.js
@@ -2,17 +2,7 @@
   const ADS_PATH = 'v2_terminal/ads_news_matrix.json';
   let adsEntries = [];
   let started = false;
-  const sideFeed = document.getElementById('sidefeed');
 
-  function pushFeedMessage(message, cls){
-    if(!sideFeed) return;
-    const msg = document.createElement('div');
-    msg.classList.add('terminal-line');
-    if(cls) msg.classList.add(cls);
-    msg.textContent = message;
-    sideFeed.appendChild(msg);
-    sideFeed.scrollTop = sideFeed.scrollHeight;
-  }
 
   function fetchAds(){
     return fetch(ADS_PATH)
@@ -60,7 +50,9 @@
       default:
         text = entry.content || '';
     }
-    pushFeedMessage(text, cls);
+    if (typeof routeToFeed === 'function') {
+      routeToFeed('ad', text, cls);
+    }
   }
 
   function injectAd(){

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -146,6 +146,12 @@ body {
   font-size: 12px;
 }
 
+#glitch-body,
+#event-body,
+#ads-body {
+  margin-bottom: 6px;
+}
+
 @media screen and (max-width: 768px) {
   #main-container {
     flex-direction: column;

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -1,11 +1,30 @@
 
 const sideFeed = document.getElementById("sidefeed");
-function pushFeedMessage(message) {
-  if (!sideFeed) return;
+
+function routeToFeed(type, content, cls) {
+  const map = {
+    glitch: document.getElementById("glitch-body"),
+    event: document.getElementById("event-body"),
+    ad: document.getElementById("ads-body"),
+  };
+  const target = map[type] || sideFeed;
+  if (!target) return;
+
   const msg = document.createElement("div");
-  msg.textContent = message;
-  sideFeed.appendChild(msg);
-  sideFeed.scrollTop = sideFeed.scrollHeight;
+  msg.classList.add("terminal-line");
+  if (cls) msg.classList.add(cls);
+  msg.textContent = content;
+  target.appendChild(msg);
+
+  if (sideFeed) {
+    sideFeed.scrollTop = sideFeed.scrollHeight;
+  }
+}
+
+window.routeToFeed = routeToFeed;
+
+function pushFeedMessage(message, cls) {
+  routeToFeed("event", message, cls);
 }
 
 function routeCommand(command) {


### PR DESCRIPTION
## Summary
- route messages to specific feed containers with `routeToFeed`
- show dedicated feed sections for glitch, events and ads
- update ads system to use `routeToFeed`
- style feed sections for spacing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68533706cd2483218b34fade89512726