### PR TITLE
Implement feed sections for terminal layout

### DIFF
--- a/v2_terminal/ads_core.js
+++ b/v2_terminal/ads_core.js
@@ -50,8 +50,8 @@
       default:
         text = entry.content || '';
     }
-    if (typeof routeToFeed === 'function') {
-      routeToFeed('ad', text, cls);
+    if (typeof routeMessageToFeed === 'function') {
+      routeMessageToFeed('reklama', text, cls);
     }
   }
 

--- a/v2_terminal/mvpsite_v_2_terminal.html
+++ b/v2_terminal/mvpsite_v_2_terminal.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NetTerm v2 – MVP Interface</title>
   <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
   <style>
     html, body {
       margin: 0;
@@ -28,18 +29,18 @@
       width: 100vw;
       overflow: hidden;
     }
-    .terminal {
+    #terminal-column {
       flex: 2;
-      width: auto;
-      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background-color: #050505;
       border: 2px solid #00ff99;
       padding: 10px;
-      background-color: #050505;
       box-shadow: 0 0 15px #00ff99;
       box-sizing: border-box;
       overflow-y: auto;
     }
-    #feeds-container {
+    #feed-zone {
       flex: 1;
       display: flex;
       flex-direction: column;
@@ -48,15 +49,21 @@
       border-left: 2px solid #111;
     }
 
-    .feed {
+    .feed-section {
       flex: 1;
-      padding: 10px;
+      padding: 4px;
+      margin: 2px 0;
       font-family: monospace;
       font-size: 12px;
+      overflow-y: auto;
+      background-color: #0a0a0a;
+      border: 1px solid #111;
     }
 
-    .feed-scroll {
-      overflow-y: auto;
+    .feed-section h4 {
+      margin: 0 0 2px 0;
+      font-size: 10px;
+      color: #888;
     }
     .prompt::before {
       content: '> ';
@@ -83,7 +90,7 @@
         flex-direction: column;
       }
 
-      #feeds-container {
+      #feed-zone {
         height: 30vh;
         border-left: none;
         border-top: 2px solid #111;
@@ -93,8 +100,8 @@
 </head>
 <body>
   <div id="main-container">
-    <div id="core-terminal" class="terminal">
-      <div id="log" class="log">
+    <div id="terminal-column">
+      <div id="terminal-output" class="log">
         :: SYSTEM ONLINE
         :: Witaj w NetTerm v2 Interface
         :: Wpisz 'help' aby zobaczyć dostępne komendy
@@ -104,17 +111,19 @@
         <input type="text" id="terminal-input" autofocus autocomplete="off">
       </div>
     </div>
-    <div id="feeds-container">
-      <div id="feed-glitch" class="feed feed-scroll"></div>
-      <div id="feed-ads" class="feed feed-scroll"></div>
-      <div id="feed-event" class="feed feed-scroll"></div>
+    <div id="feed-zone">
+      <div class="feed-section" id="feed-zapis"><h4>[ZAPIS]</h4><div class="feed-body"></div></div>
+      <div class="feed-section" id="feed-info"><h4>[INFO]</h4><div class="feed-body"></div></div>
+      <div class="feed-section" id="feed-event"><h4>[EVENT]</h4><div class="feed-body"></div></div>
+      <div class="feed-section" id="feed-glitch"><h4>[GLITCH]</h4><div class="feed-body"></div></div>
+      <div class="feed-section" id="feed-reklama"><h4>[REKLAMA]</h4><div class="feed-body"></div></div>
     </div>
   </div>
 
   <script type="module">
     import { getLunaResponse } from './luna.js';
     const input = document.getElementById('terminal-input');
-    const log = document.getElementById('log');
+    const log = document.getElementById('terminal-output');
 
     const commandMap = {
       remor: 'remor_page.html',

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -197,3 +197,40 @@ body {
 .feed-scroll {
   overflow-y: auto;
 }
+
+/* structured feed zone layout */
+#feed-zone {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #050505;
+  color: #66ff66;
+  border-left: 1px solid #111;
+  padding: 5px;
+}
+
+#terminal-column {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  background: black;
+  color: #00ff99;
+  padding: 10px;
+}
+
+.feed-section {
+  flex: 1;
+  overflow-y: auto;
+  margin: 2px 0;
+  padding: 4px;
+  background-color: #0a0a0a;
+  border: 1px solid #111;
+  font-family: monospace;
+  font-size: 11px;
+}
+
+.feed-section h4 {
+  margin: 0 0 2px 0;
+  font-size: 10px;
+  color: #888;
+}

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -1,30 +1,27 @@
 
-const sideFeed = document.getElementById("sidefeed");
-
-function routeToFeed(type, content, cls) {
+function routeMessageToFeed(type, content, cls) {
   const map = {
-    glitch: document.getElementById("glitch-body"),
-    event: document.getElementById("event-body"),
-    ad: document.getElementById("ads-body"),
+    zapis: "feed-zapis",
+    info: "feed-info",
+    event: "feed-event",
+    glitch: "feed-glitch",
+    reklama: "feed-reklama",
   };
-  const target = map[type] || sideFeed;
-  if (!target) return;
+  const container = document.querySelector(`#${map[type]} .feed-body`);
+  if (!container) return;
 
   const msg = document.createElement("div");
   msg.classList.add("terminal-line");
   if (cls) msg.classList.add(cls);
   msg.textContent = content;
-  target.appendChild(msg);
-
-  if (sideFeed) {
-    sideFeed.scrollTop = sideFeed.scrollHeight;
-  }
+  container.appendChild(msg);
+  container.scrollTop = container.scrollHeight;
 }
 
-window.routeToFeed = routeToFeed;
+window.routeMessageToFeed = routeMessageToFeed;
 
 function pushFeedMessage(message, cls) {
-  routeToFeed("event", message, cls);
+  routeMessageToFeed("event", message, cls);
 }
 
 function routeCommand(command) {


### PR DESCRIPTION
## Summary
- build structured feed containers on the right column
- route injected messages per category
- update ad module to target new feed zone
- tweak terminal HTML markup for new sections

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68533afb4a748321a55bd03a4c2e9740