### PR TITLE
Add glitch inject overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <div class="overlay"></div>
+  <div id="glitch-layer"></div>
   <div id="main-container">
     <div id="terminal-column">
       <div id="terminal" class="terminal"></div>
@@ -94,6 +95,19 @@ function addLine(text){
   terminal.appendChild(d);
   terminal.scrollTop=terminal.scrollHeight;
 }
+
+function glitchInject(text){
+  const layer=document.getElementById('glitch-layer');
+  if(!layer) return;
+  const span=document.createElement('span');
+  span.classList.add('glitch-text');
+  span.textContent=text;
+  span.style.left=Math.random()*100+'%';
+  span.style.top=Math.random()*100+'%';
+  layer.appendChild(span);
+  setTimeout(()=>span.remove(),2000);
+}
+window.glitchInject = glitchInject;
 
 function introAnim(i=0){
   if(i<intro.length){addLine(intro[i]); setTimeout(()=>introAnim(i+1),90);}

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -55,6 +55,25 @@ body {
   z-index: 1;
 }
 
+#glitch-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.glitch-text {
+  position: absolute;
+  color: #ff0077;
+  font-family: 'Share Tech Mono', monospace;
+  pointer-events: none;
+  white-space: pre;
+  animation: flicker 1s ease-in-out;
+}
+
 .terminal-line {
   white-space: pre-wrap;
   animation: flicker 1s ease-in-out;


### PR DESCRIPTION
## Summary
- add `#glitch-layer` container to hold glitch text
- implement `glitchInject(text)` for random glitch labels
- style `.glitch-text` elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534782de4c8321ac5a30a691797abe