### PR TITLE
Add mobile glitch overlay and column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="v2_terminal/style.css">
 </head>
 <body>
-  <div class="overlay"></div>
+  <div id="glitch-layer" class="overlay"></div>
   <div id="main-container">
     <div id="terminal-column">
       <div id="terminal" class="terminal"></div>

--- a/v2_terminal/style.css
+++ b/v2_terminal/style.css
@@ -55,6 +55,16 @@ body {
   z-index: 1;
 }
 
+#glitch-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 3;
+}
+
 .terminal-line {
   white-space: pre-wrap;
   animation: flicker 1s ease-in-out;
@@ -153,6 +163,18 @@ body {
 }
 
 @media screen and (max-width: 768px) {
+  #main-container {
+    flex-direction: column;
+  }
+
+  #feed-zone {
+    height: 30vh;
+    border-left: none;
+    border-top: 2px solid #111;
+  }
+}
+
+@media screen and (max-width: 600px) {
   #main-container {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- keep a dedicated `#glitch-layer` element for the screen overlay
- ensure the overlay covers the whole viewport
- support column layout on very small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685347847d54832194d2ca26b6c1ef8e