### PR TITLE
Support encrypted feed routing

### DIFF
--- a/donka_feed_shell.html
+++ b/donka_feed_shell.html
@@ -24,8 +24,8 @@
     </div>
   </div>
   <!-- core routing + extras -->
-  <script src="v2_terminal/terminal_router_final.js"></script>
   <script src="donka_router.js"></script>
+  <script src="v2_terminal/terminal_router_final.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>
   <script>
     const terminal = document.getElementById("terminal");

--- a/donka_router.js
+++ b/donka_router.js
@@ -10,7 +10,22 @@
     glitch: 'glitch-layer'
   };
 
+  function appendEncrypted(content){
+    const container = document.querySelector('#feed-encrypt .feed-body') ||
+                      document.querySelector('#encrypt-feed .feed-body');
+    if(!container) return;
+    const div = document.createElement('div');
+    div.classList.add('terminal-line','fade-encrypt');
+    div.textContent = content;
+    container.appendChild(div);
+    container.scrollTop = container.scrollHeight;
+  }
+
   function routeMessage(type, content, cls){
+    if(type === 'encrypt'){
+      appendEncrypted(content);
+      return;
+    }
     const id = map[type];
     const container = id && document.querySelector(`#${id} .feed-body`);
     if(!container) return;
@@ -18,7 +33,6 @@
     div.classList.add('terminal-line');
     if(cls) div.classList.add(cls);
     if(type==='reklama' || type==='ad') div.classList.add('flash-banner');
-    if(type==='encrypt') div.classList.add('fade-encrypt');
     div.textContent = content;
     container.appendChild(div);
     container.scrollTop = container.scrollHeight;
@@ -41,4 +55,5 @@
   window.routeMessageByPrefix = routeMessageByPrefix;
   window.routeMessageToFeed = routeMessage; // compatibility
   window.glitchInject = glitchInject;
+  window.appendEncrypted = appendEncrypted;
 })();

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     </div>
   </div>
   <!-- core routing + extras -->
+  <script src="donka_router.js"></script>
   <script src="v2_terminal/terminal_router_final.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>
   <script>

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -12,6 +12,11 @@ function routeMessageToFeed(type, content, cls) {
   const container = document.querySelector(`#${map[type]} .feed-body`);
   if (!container) return;
 
+  if (type === "encrypt" && typeof appendEncrypted === "function") {
+    appendEncrypted(content);
+    return;
+  }
+
   const msg = document.createElement("div");
   msg.classList.add("terminal-line");
   if (cls) msg.classList.add(cls);


### PR DESCRIPTION
## Summary
- specialize encrypted messages in `terminal_router_final.js`
- add `appendEncrypted` helper and expose from `donka_router.js`
- load `donka_router.js` before routing scripts in HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685349befb5c8321bcb58345c8e804d6