### PR TITLE
Add journal feature to terminal

### DIFF
--- a/donka_feed_shell.html
+++ b/donka_feed_shell.html
@@ -26,6 +26,7 @@
   <!-- core routing + extras -->
   <script src="donka_router.js"></script>
   <script src="v2_terminal/terminal_router_final.js"></script>
+  <script src="v2_terminal/journal.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>
   <script>
     const terminal = document.getElementById("terminal");

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <!-- core routing + extras -->
   <script src="donka_router.js"></script>
   <script src="v2_terminal/terminal_router_final.js"></script>
+  <script src="v2_terminal/journal.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>
   <script>
     const terminal = document.getElementById("terminal");

--- a/journal.json
+++ b/journal.json
@@ -1,0 +1,14 @@
+{
+  "entries": [
+    {
+      "timestamp": "2024-05-01T12:00:00Z",
+      "author": "Admin",
+      "entry": "System initiated."
+    },
+    {
+      "timestamp": "2024-05-02T15:30:00Z",
+      "author": "Donka",
+      "entry": "First memory imprint recorded."
+    }
+  ]
+}

--- a/v2_terminal/journal.js
+++ b/v2_terminal/journal.js
@@ -1,0 +1,41 @@
+(function(){
+  const JOURNAL_PATH = 'journal.json';
+  let entries = [];
+
+  function load(){
+    return fetch(JOURNAL_PATH)
+      .then(r => r.json())
+      .then(data => {
+        entries = data.entries || [];
+        try{ localStorage.setItem('journalCache', JSON.stringify(entries)); }catch(e){}
+      })
+      .catch(() => {
+        try{
+          const cached = localStorage.getItem('journalCache');
+          if(cached){ entries = JSON.parse(cached); }
+        }catch(e){}
+      });
+  }
+
+  function save(){
+    try{ localStorage.setItem('journalCache', JSON.stringify(entries)); }catch(e){}
+  }
+
+  function write(entryText, author='anon'){
+    const entry = { timestamp: Date.now(), author, entry: entryText };
+    entries.push(entry);
+    save();
+    return entry;
+  }
+
+  function read(idx){
+    return entries[idx];
+  }
+
+  function all(){
+    return entries.slice();
+  }
+
+  window.journal = { load, write, read, all };
+  window.addEventListener('load', load);
+})();

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -76,8 +76,43 @@ function routeCommand(command) {
       }
       break;
 
+    case command === "journal run":
+      if (window.journal && typeof window.journal.load === "function") {
+        window.journal.load().then(() => {
+          pushFeedMessage("[JOURNAL] loaded");
+        });
+      }
+      break;
+
+    case command.startsWith("journal read"):
+      const idx = parseInt(command.split(" ")[2]);
+      const entry = window.journal && window.journal.read(idx);
+      if (entry) {
+        line.textContent = `[JOURNAL ${idx}] ${new Date(entry.timestamp).toLocaleString()} <${entry.author}> ${entry.entry}`;
+      } else {
+        line.textContent = `[JOURNAL] entry ${idx} not found`;
+      }
+      terminal.appendChild(line);
+      break;
+
+    case command.startsWith("journal write"):
+      const m = command.match(/^journal write\s+\"(.+)\"$/);
+      if (m && window.journal) {
+        window.journal.write(m[1], "user");
+        pushFeedMessage("[JOURNAL] entry added");
+      } else {
+        line.textContent = '[JOURNAL] usage: journal write "<text>"';
+        terminal.appendChild(line);
+      }
+      break;
+
+    case command === "journal help":
+      line.textContent = "journal run | journal read <idx> | journal write \"<text>\"";
+      terminal.appendChild(line);
+      break;
+
     case command === "help":
-      line.textContent = "COMMANDS: inject profile:<name> | trace:<name> | link:<name> | db:search <term> | inject ads_core | clear";
+      line.textContent = "COMMANDS: inject profile:<name> | trace:<name> | link:<name> | db:search <term> | inject ads_core | journal run | journal read <idx> | journal write \"<text>\" | journal help | clear";
       terminal.appendChild(line);
       break;
 


### PR DESCRIPTION
## Summary
- create `journal.js` for loading/saving journal entries
- wire journal commands into terminal router
- expose journal commands in help text
- include journal script on pages with the terminal
- add example `journal.json` file

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_686002140df08321acc58347bb8a663d