### PR TITLE
Fix duplicated responses and add check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,15 @@ node v1_luna_legacy/luna.js
 
 ## 🔧 Dev Tools (opcjonalne)
 
-Repozytorium nie zawiera domyślnie skryptów developerskich. W razie potrzeby
-możesz utworzyć własne narzędzia do walidacji i rozszerzania plików JSON.
+Repozytorium zawiera prosty skrypt pomagający pilnować spójności `responses.json`.
+Uruchom go przed dodaniem nowych odpowiedzi, aby upewnić się, że nie ma zduplikowanych kluczy:
+
+```bash
+python scripts/check_duplicates.py
+```
+
+Skrypt wypisze listę powtórzonych kluczy lub informację o ich braku. Możesz również
+rozbudować go o własne walidacje JSON.
 
 ---
 

--- a/responses.json
+++ b/responses.json
@@ -1,6 +1,5 @@
-{ "menu_start": "\n> 🌐 GLITCHWAVE TERMINAL – NightCity Protocol v1\n> Dostępne wpisy:\n- rabur:deklaracja\n- krokiet:ukrycie\n- kyiosuke:glitch\n- mila:przebudzenie\n- kampania:cel\n> Wpisz 'help' by zobaczyć więcej.\n", "rabur:deklaracja": "'Jeśli mam zginąć – to z interfejsem w dłoni.'", "krokiet:ukrycie": "Krokiet świadomie wyłączył lokalizator i komunikator, znikając z systemu.", "kyiosuke:glitch": "Kyiosuke to niestabilny sygnał peryferyjny. Kanał 9. Kontakt: przerwany.", "mila:przebudzenie": "Mila zaczyna rozumieć swoje miejsce w narracji. Cisza staje się jej językiem.", "kampania:cel": "Unieszkodliwić pochodne kiosuke. Alto to pierwszy. SubEcho trwa.", "terminal:milczenie": "Brak odpowiedzi = odpowiedź. Donka notuje to jako reakcję.", 
-
-
+{
+  "menu_start": "\n> 🌐 GLITCHWAVE TERMINAL – NightCity Protocol v1\n> Dostępne wpisy:\n- rabur:deklaracja\n- krokiet:ukrycie\n- kyiosuke:glitch\n- mila:przebudzenie\n- kampania:cel\n> Wpisz 'help' by zobaczyć więcej.\n",
   "needleeye": "[LOKACJA] GR-7 – mgła, transmisja, echo ALTO.",
   "watson": "[REJON] – uzależnienie, rozpad, odzysk Krokieta.",
   "alto": "[OBIEKT] – eksperymentalna jednostka kiosuke. Fragmenty pamięci.",
@@ -17,21 +16,15 @@
   "event:echo_activation": "Fragment pamięci kiosuke aktywowany. Rabur przejmuje echo.",
   "event:trauma_test": "Rzut 7 – Krokiet maskuje rozpad. Donka wykrywa.",
   "subecho:reakcja": "ALTO emituje niezsynchroznizowaną emocję. Luna analizuje.",
-  "rabur:deklaracja": "Jeśli mam zginąć – to z interfejsem w dłoni.",
   "rabur:czy_się_boi": "[PYTANIE] Brak jednoznacznej odpowiedzi. Rabur zawiesza emocje.",
   "rabur:kiedy_milczy": "[REJESTR] Milczenie jako forma decyzji. Stan: kontrolowany.",
   "donka:protokol": "[TRYB] Protokół Mentalnego Sygnału aktywowany. Inicjator: Luna.",
   "donka:tryb_ratyfikacji": "[TRYB] Zgoda systemowa nadana. Donka zatwierdza rzeczywistość.",
   "donka:co_wie": "[ODPOWIEDŹ] Donka wie wszystko, czego Ty nie chcesz wiedzieć.",
-  "krokiet:ukrycie": "[STAN] Ukrycie: aktywne. Nadajnik wyłączony.",
   "krokiet:echo_porażki": "[EFEKT] Porażka zakodowana jako sygnał bierny.",
   "mila:echosen": "[STAN] Mila śni echem systemu. Rejestr: nieciągły.",
-  "mila:przebudzenie": "[ZDARZENIE] Mila budzi się przez dotyk. Komenda nieznana.",
-  "kyiosuke:glitch": "[GLITCH] Transmisja dryfuje poza kanałem. Ślad zerwany.",
-  "kampania:cel": "eliminacja pochodnych kiosuke.",
   "glossary:alto": "ALTO – obiekt eksperymentalny, fragmentuje pamięć, może zawierać inne instancje.",
   "glossary:glitchwave": "Glitchwave – systemowy miernik błędu i napięcia, waluta rozpadów.",
-  "terminal:milczenie": "[EFEKT] Brak odpowiedzi = odpowiedź.",
   "zjawa:glitch": "[ANOMALIA] Zjawa dryfuje. Odpowiedź opóźniona.",
   "zjawa:reset": "[RESTART] Reset wykonany bez potwierdzenia.",
   "zjawa:echo": "[POWTÓRZENIE] Sygnał już był. Przypomnienie nastąpiło samoistnie.",
@@ -101,5 +94,11 @@
   "odpowiedz:zmienność": "[ODP] Systemy nie są stałe. Każde pytanie otwiera inną wersję rzeczywistości.",
   "fakt:takamura": "[POSTAĆ] Goro Takamura – były agent Arasaki. Działa według własnego kodeksu.",
   "fakt:cyberdeck": "[TECHNOLOGIA] Cyberdeck – interfejs netrunnera do włamań, hakowania i mapowania sieci.",
-  "terminal:menu_start": "┌──────────────────────────────┐\n│  ☰ GLITCHWAVE: ACCESS NODE  │\n├──────────────────────────────┤\n│  Typuj jedną z komend:       │\n│                              │\n│  • rabur          • donka    │\n│  • mila           • krokiet  │\n│  • glitchwave     • kyiosuke │\n│  • glossary:alto  • terminal │\n│                              │\n│  wpisz 'help' aby uzyskać... │\n└──────────────────────────────┘"
+  "terminal:menu_start": "┌──────────────────────────────┐\n│  ☰ GLITCHWAVE: ACCESS NODE  │\n├──────────────────────────────┤\n│  Typuj jedną z komend:       │\n│                              │\n│  • rabur          • donka    │\n│  • mila           • krokiet  │\n│  • glitchwave     • kyiosuke │\n│  • glossary:alto  • terminal │\n│                              │\n│  wpisz 'help' aby uzyskać... │\n└──────────────────────────────┘",
+  "rabur:deklaracja": "Jeśli mam zginąć – to z interfejsem w dłoni.",
+  "krokiet:ukrycie": "[STAN] Ukrycie: aktywne. Nadajnik wyłączony.",
+  "kyiosuke:glitch": "[GLITCH] Transmisja dryfuje poza kanałem. Ślad zerwany.",
+  "mila:przebudzenie": "[ZDARZENIE] Mila budzi się przez dotyk. Komenda nieznana.",
+  "kampania:cel": "Unieszkodliwić pochodne kiosuke. Alto to pierwszy. SubEcho trwa.",
+  "terminal:milczenie": "[EFEKT] Brak odpowiedzi = odpowiedź."
 }

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import json
+import sys
+from collections import defaultdict
+
+filename = sys.argv[1] if len(sys.argv) > 1 else 'responses.json'
+
+with open(filename, 'r', encoding='utf-8') as f:
+    content = f.read()
+
+# Preserve order and duplicates
+pairs = json.loads(content, object_pairs_hook=list)
+
+counts = defaultdict(list)
+
+for key, value in pairs:
+    counts[key].append(value)
+
+found = False
+for key, values in counts.items():
+    if len(values) > 1:
+        found = True
+        print(f"Duplicate key: {key} ({len(values)})")
+        for i, val in enumerate(values, 1):
+            preview = val
+            if isinstance(preview, str) and len(preview) > 60:
+                preview = preview[:60] + '...'
+            print(f"  {i}. {preview}")
+
+if not found:
+    print("No duplicate keys found.")


### PR DESCRIPTION
## Summary
- remove duplicate keys in `responses.json`
- add `scripts/check_duplicates.py` for spotting duplicates
- document the new script in the README

## Testing
- `python scripts/check_duplicates.py`
- `python3 -m json.tool responses.json > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6860021635e08321ba9c52a652045fb7