### PR TITLE
Centralize routing logic

### DIFF
--- a/donka_feed_shell.html
+++ b/donka_feed_shell.html
@@ -24,6 +24,7 @@
     </div>
   </div>
   <!-- core routing + extras -->
+  <script src="feed_router.js"></script>
   <script src="donka_router.js"></script>
   <script src="v2_terminal/terminal_router_final.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>

--- a/donka_router.js
+++ b/donka_router.js
@@ -10,50 +10,19 @@
     glitch: 'glitch-layer'
   };
 
-  function appendEncrypted(content){
-    const container = document.querySelector('#feed-encrypt .feed-body') ||
-                      document.querySelector('#encrypt-feed .feed-body');
-    if(!container) return;
-    const div = document.createElement('div');
-    div.classList.add('terminal-line','fade-encrypt');
-    div.textContent = content;
-    container.appendChild(div);
-    container.scrollTop = container.scrollHeight;
-  }
-
-  function routeMessage(type, content, cls){
-    if(type === 'encrypt'){
-      appendEncrypted(content);
-      return;
-    }
-    const id = map[type];
-    const container = id && document.querySelector(`#${id} .feed-body`);
-    if(!container) return;
-    const div = document.createElement('div');
-    div.classList.add('terminal-line');
-    if(cls) div.classList.add(cls);
-    if(type==='reklama' || type==='ad') div.classList.add('flash-banner');
-    div.textContent = content;
-    container.appendChild(div);
-    container.scrollTop = container.scrollHeight;
-  }
-
-  function routeMessageByPrefix(text, cls){
-    const m = text.match(/^\[(glitch|info|event|reklama|zapis|data|encrypt)\]/i);
-    if(m){
-      routeMessage(m[1].toLowerCase(), text, cls);
-      return true;
-    }
-    return false;
+  if(!window.routeMessageToFeed){
+    const router = createFeedRouter(map, {flashReklama:true});
+    window.routeMessageToFeed = router.routeMessageToFeed;
+    window.routeMessageByPrefix = router.routeMessageByPrefix;
+    window.routeMessage = router.routeMessageToFeed; // compatibility
+    window.appendEncrypted = router.appendEncrypted;
   }
 
   function glitchInject(text){
-    routeMessage('glitch', text);
+    if(typeof window.routeMessageToFeed === 'function'){
+      window.routeMessageToFeed('glitch', text);
+    }
   }
 
-  window.routeMessage = routeMessage;
-  window.routeMessageByPrefix = routeMessageByPrefix;
-  window.routeMessageToFeed = routeMessage; // compatibility
   window.glitchInject = glitchInject;
-  window.appendEncrypted = appendEncrypted;
 })();

--- a/feed_router.js
+++ b/feed_router.js
@@ -1,0 +1,41 @@
+(function(global){
+  function createFeedRouter(map, opts={}) {
+    const flashReklama = !!opts.flashReklama;
+    function appendEncrypted(content){
+      const id = map['encrypt'];
+      const container = id && document.querySelector(`#${id} .feed-body`);
+      if(!container) return;
+      const div = document.createElement('div');
+      div.classList.add('terminal-line','fade-encrypt');
+      div.textContent = content;
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+    }
+    function routeMessageToFeed(type, content, cls){
+      if(type === 'encrypt'){
+        appendEncrypted(content);
+        return;
+      }
+      const id = map[type];
+      const container = id && document.querySelector(`#${id} .feed-body`);
+      if(!container) return;
+      const div = document.createElement('div');
+      div.classList.add('terminal-line');
+      if(cls) div.classList.add(cls);
+      if(flashReklama && (type==='reklama' || type==='ad')) div.classList.add('flash-banner');
+      div.textContent = content;
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+    }
+    function routeMessageByPrefix(text, cls){
+      const m = text.match(/^\[(glitch|info|event|reklama|zapis|data|encrypt)\]/i);
+      if(m){
+        routeMessageToFeed(m[1].toLowerCase(), text, cls);
+        return true;
+      }
+      return false;
+    }
+    return {routeMessageToFeed, routeMessageByPrefix, appendEncrypted};
+  }
+  global.createFeedRouter = createFeedRouter;
+})(window);

--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
     </div>
   </div>
   <!-- core routing + extras -->
-  <script src="donka_router.js"></script>
+  <script src="feed_router.js"></script>
   <script src="v2_terminal/terminal_router_final.js"></script>
+  <script src="donka_router.js"></script>
   <script src="v2_terminal/profile_extras.js"></script>
   <script>
     const terminal = document.getElementById("terminal");

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -1,5 +1,5 @@
 
-function routeMessageToFeed(type, content, cls) {
+(function(){
   const map = {
     zapis: "feed-zapis",
     info: "feed-info",
@@ -9,35 +9,15 @@ function routeMessageToFeed(type, content, cls) {
     data: "feed-data",
     encrypt: "feed-encrypt",
   };
-  const container = document.querySelector(`#${map[type]} .feed-body`);
-  if (!container) return;
 
-  if (type === "encrypt" && typeof appendEncrypted === "function") {
-    appendEncrypted(content);
-    return;
+  if(!window.routeMessageToFeed){
+    const router = createFeedRouter(map);
+    window.routeMessageToFeed = router.routeMessageToFeed;
+    window.routeMessageByPrefix = router.routeMessageByPrefix;
+    window.routeMessage = router.routeMessageToFeed;
+    window.appendEncrypted = router.appendEncrypted;
   }
-
-  const msg = document.createElement("div");
-  msg.classList.add("terminal-line");
-  if (cls) msg.classList.add(cls);
-  msg.textContent = content;
-  container.appendChild(msg);
-  container.scrollTop = container.scrollHeight;
-}
-
-window.routeMessageToFeed = routeMessageToFeed;
-
-function routeMessageByPrefix(text, cls){
-  const match = text.match(/^\[(glitch|info|event|reklama|zapis|data|encrypt)\]/i);
-  if(match){
-    const type = match[1].toLowerCase();
-    routeMessageToFeed(type, text, cls);
-    return true;
-  }
-  return false;
-}
-
-window.routeMessageByPrefix = routeMessageByPrefix;
+})();
 
 function pushFeedMessage(message, cls) {
   routeMessageToFeed("event", message, cls);


### PR DESCRIPTION
## Summary
- add `feed_router.js` to share feed routing logic
- refactor `donka_router.js` and `terminal_router_final.js` to use the shared module
- include the new router in `index.html` and `donka_feed_shell.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6860021845e483218687524ba07a2055