### PR TITLE
Improve journal entry handling

### DIFF
--- a/v2_terminal/journal.js
+++ b/v2_terminal/journal.js
@@ -22,7 +22,8 @@
   }
 
   function write(entryText, author='anon'){
-    const entry = { timestamp: Date.now(), author, entry: entryText };
+    if (!entryText.trim()) return null;
+    const entry = { timestamp: new Date().toISOString(), author, entry: entryText };
     entries.push(entry);
     save();
     return entry;

--- a/v2_terminal/terminal_router_final.js
+++ b/v2_terminal/terminal_router_final.js
@@ -78,8 +78,13 @@ function routeCommand(command) {
     case command.startsWith("journal write"):
       const m = command.match(/^journal write\s+\"(.+)\"$/);
       if (m && window.journal) {
-        window.journal.write(m[1], "user");
-        pushFeedMessage("[JOURNAL] entry added");
+        const result = window.journal.write(m[1], "user");
+        if (result) {
+          pushFeedMessage("[JOURNAL] entry added");
+        } else {
+          line.textContent = '[JOURNAL] empty entry not saved';
+          terminal.appendChild(line);
+        }
       } else {
         line.textContent = '[JOURNAL] usage: journal write "<text>"';
         terminal.appendChild(line);


### PR DESCRIPTION
## Summary
- sanitize journal write to ignore empty entries and record timestamps in ISO format
- surface an error message for blank journal writes

## Testing
- `python3 scripts/check_duplicates.py`

------
https://chatgpt.com/codex/tasks/task_e_68601760b4648321a1697ced6d38ecf9