### PR TITLE
Add GitHub sync for journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ Plik `responses.json` powinien być aktualizowany iteracyjnie z zachowaniem spó
 
 ---
 
+## 🔄 Synchronizacja journala z GitHub
+
+`journal.json` może być automatycznie aktualizowany w repozytorium przy użyciu
+GitHub REST API. Aby włączyć tę opcję:
+
+1. Wygeneruj **Personal Access Token** z uprawnieniami `repo` na GitHubie.
+2. Przed załadowaniem skryptu `v2_terminal/journal.js` ustaw globalne zmienne:
+
+   ```html
+   <script>
+     window.JOURNAL_GITHUB_TOKEN = 'TWÓJ_TOKEN';
+     window.JOURNAL_GITHUB_REPO = 'użytkownik/nazwa_repo';
+     // opcjonalnie
+     window.JOURNAL_GITHUB_BRANCH = 'main';
+   </script>
+   ```
+
+3. Każde wywołanie `journal.write()` spowoduje dopisanie wpisu do pliku
+   `journal.json` w podanym repozytorium.
+
+---
+
 ## 👤 Autor i Kontakt
 
 **Piotr Krokosz (Krokiet)**  

--- a/v2_terminal/journal.js
+++ b/v2_terminal/journal.js
@@ -1,5 +1,8 @@
 (function(){
   const JOURNAL_PATH = 'journal.json';
+  const GITHUB_REPO = window.JOURNAL_GITHUB_REPO;
+  const GITHUB_TOKEN = window.JOURNAL_GITHUB_TOKEN;
+  const GITHUB_BRANCH = window.JOURNAL_GITHUB_BRANCH || 'main';
   let entries = [];
 
   function load(){
@@ -21,10 +24,46 @@
     try{ localStorage.setItem('journalCache', JSON.stringify(entries)); }catch(e){}
   }
 
+  function syncToGitHub(entry){
+    if(!GITHUB_TOKEN || !GITHUB_REPO){
+      return Promise.resolve();
+    }
+    const headers = {
+      'Authorization': 'token ' + GITHUB_TOKEN,
+      'Accept': 'application/vnd.github.v3+json'
+    };
+    const api = `https://api.github.com/repos/${GITHUB_REPO}/contents/${JOURNAL_PATH}`;
+    return fetch(`${api}?ref=${GITHUB_BRANCH}`, { headers })
+      .then(r => r.json())
+      .then(data => {
+        const sha = data.sha;
+        let content = '';
+        try{ content = atob(data.content.replace(/\n/g, '')); }catch(e){}
+        let json;
+        try{ json = JSON.parse(content); }catch(e){ json = { entries: [] }; }
+        if(!Array.isArray(json.entries)) json.entries = [];
+        json.entries.push(entry);
+        const body = {
+          message: 'Add journal entry',
+          content: btoa(JSON.stringify(json, null, 2)),
+          sha,
+          branch: GITHUB_BRANCH
+        };
+        return fetch(api, {
+          method: 'PUT',
+          headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+          body: JSON.stringify(body)
+        });
+      });
+  }
+
   function write(entryText, author='anon'){
     const entry = { timestamp: Date.now(), author, entry: entryText };
     entries.push(entry);
     save();
+    if(GITHUB_TOKEN && GITHUB_REPO){
+      syncToGitHub(entry).catch(e => console.error('GitHub sync failed', e));
+    }
     return entry;
   }
 
@@ -36,6 +75,6 @@
     return entries.slice();
   }
 
-  window.journal = { load, write, read, all };
+  window.journal = { load, write, read, all, syncToGitHub };
   window.addEventListener('load', load);
 })();


### PR DESCRIPTION
## Summary
- add optional GitHub repo config in `journal.js`
- implement `syncToGitHub` and call it from `write()`
- document how to enable journal sync with a PAT in README

## Testing
- `python scripts/check_duplicates.py`

------
https://chatgpt.com/codex/tasks/task_e_686017618a9483219890edbaad4b5824